### PR TITLE
Fixes issue 35 - Server-side validation failure not honoring [Display] attribute

### DIFF
--- a/FoolProof.Core/Base Classes/ModelAwareValidationAttribute.cs
+++ b/FoolProof.Core/Base Classes/ModelAwareValidationAttribute.cs
@@ -11,8 +11,10 @@ namespace FoolProof.Core
         public override string FormatErrorMessage(string name)
         {
             if (string.IsNullOrEmpty(ErrorMessageResourceName) && string.IsNullOrEmpty(ErrorMessage))
+            {
                 ErrorMessage = DefaultErrorMessage;
-            
+            }
+
             return base.FormatErrorMessage(name);
         }
 
@@ -28,26 +30,26 @@ namespace FoolProof.Core
             get { return this.GetType().Name.Replace("Attribute", ""); }
         }
 
-		public Dictionary<string, object> ClientValidationParameters
-		{
-			get { return GetClientValidationParameters().ToDictionary(kv => kv.Key.ToLower(), kv => kv.Value); }
-		}
+        public Dictionary<string, object> ClientValidationParameters
+        {
+            get { return GetClientValidationParameters().ToDictionary(kv => kv.Key.ToLower(), kv => kv.Value); }
+        }
 
 
-		protected override ValidationResult IsValid(object value, ValidationContext validationContext)
-		{
-			bool validate = IsValid(value, validationContext.ObjectInstance);
-			if (validate)
-			{
-				return ValidationResult.Success;
-			}
-			else
-			{
-				return new ValidationResult(FormatErrorMessage(validationContext.MemberName));
-			}
-		}
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            bool validate = IsValid(value, validationContext.ObjectInstance);
+            if (validate)
+            {
+                return ValidationResult.Success;
+            }
+            else
+            {
+                return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
+            }
+        }
 
-		protected virtual IEnumerable<KeyValuePair<string, object>> GetClientValidationParameters()
+        protected virtual IEnumerable<KeyValuePair<string, object>> GetClientValidationParameters()
         {
             return new KeyValuePair<string, object>[0];
         }


### PR DESCRIPTION
Fixes ModelAwareValidationAttribute protected IsValid method to use validationContext.DisplayName instead of validationContext.MemberName