### PR TITLE
Fix: RegularExpressionIf validates regex even if the value is null or empty

### DIFF
--- a/FoolProof.Core/RegularExpressionIf.cs
+++ b/FoolProof.Core/RegularExpressionIf.cs
@@ -18,8 +18,9 @@ namespace FoolProof.Core
 
         public override bool IsValid(object value, object dependentValue, object container)
         {
-            if (Metadata.IsValid(dependentValue, DependentValue))
-                return OperatorMetadata.Get(Operator.RegExMatch).IsValid(value, Pattern);
+	        if (Metadata.IsValid(dependentValue, DependentValue))
+                return value == null || string.IsNullOrEmpty(value.ToString().Trim()) 
+                                     || OperatorMetadata.Get(Operator.RegExMatch).IsValid(value, Pattern);
 
             return true;
         }


### PR DESCRIPTION
Fixes the issue raised here:
https://github.com/rpgkaiser/FoolProof.Core/issues/39