### PR TITLE
Use constructor-based default messages.

### DIFF
--- a/FoolProof.Core.Tests.WebApp/Controllers/HomeController.cs
+++ b/FoolProof.Core.Tests.WebApp/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using FoolProof.Core.Tests.E2eTests.WebApp.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
@@ -85,9 +86,26 @@ namespace FoolProof.Core.Tests.E2eTests.WebApp.Controllers
             ViewBag.DataType = type;
             ViewBag.PassWithNull = pwn;
             return View("LessOrEqualTo", model);
+		}
+
+		[HttpGet("complexmodel")]
+        public IActionResult ComplexModel()
+        {
+            return View("ComplexModel", new PersonalInfo());
         }
 
-        [HttpPost("validate")]
+		[HttpPost("complexmodel")]
+		public IActionResult ComplexModel(PersonalInfo? vm)
+		{
+            if (ModelState.IsValid)
+            {
+                ViewBag.SuccessMessage = "Validation succeeded";
+			}
+
+			return View("ComplexModel", vm);
+		}
+
+		[HttpPost("validate")]
         public async Task<JsonResult> Save([FromQuery]string modelTypeName)
         {
             var modelType = typeof(EqualTo).Assembly.GetType(modelTypeName)

--- a/FoolProof.Core.Tests.WebApp/Models/PersonalInfo.cs
+++ b/FoolProof.Core.Tests.WebApp/Models/PersonalInfo.cs
@@ -37,7 +37,7 @@ namespace FoolProof.Core.Tests.E2eTests.WebApp.Models
         [DataType(DataType.PhoneNumber)]
         public string? PhoneNumber { get; set; }
 
-        [RequiredIfEmpty(nameof(BirthDate))]
+        [RequiredIfEmpty(nameof(BirthDate), ErrorMessage = "Please specify your age or birthdate.")]
         [Range(1, 200)]
         public int? Age { get; set; }
 
@@ -48,20 +48,20 @@ namespace FoolProof.Core.Tests.E2eTests.WebApp.Models
         [DataType(DataType.Date)]
         [RequiredIfNotEmpty(nameof(BirthDate))]
         [RequiredIf(nameof(Education), Operator.EqualTo, EducationalLevel.Elementary)]
-        [GreaterThan(nameof(BirthDate))]
-        [LessThan(nameof(HighScoolGraduationDate))]
+        [GreaterThan(nameof(BirthDate), PassOnNull = true)]
+        [LessThan(nameof(HighScoolGraduationDate), PassOnNull = true)]
         public DateTime? ElementaryScoolGraduationDate { get; set; }
 
         [DataType(DataType.Date)]
         [RequiredIfEmpty(nameof(ElementaryScoolGraduationDate))]
         [RequiredIf(nameof(Education), Operator.EqualTo, EducationalLevel.High)]
-        [GreaterThan(nameof(ElementaryScoolGraduationDate))]
+        [GreaterThan(nameof(ElementaryScoolGraduationDate), PassOnNull = true)]
         public DateTime? HighScoolGraduationDate { get; set; }
 
         [DataType(DataType.Date)]
         [RequiredIfEmpty(nameof(HighScoolGraduationDate))]
         [RequiredIf(nameof(Age), Operator.GreaterThan, 18)]
-        [GreaterThan(nameof(HighScoolGraduationDate))]
+        [GreaterThan(nameof(HighScoolGraduationDate), PassOnNull = true)]
         public DateTime? CollegeGraduationDate { get; set; }
     }
 }

--- a/FoolProof.Core.Tests.WebApp/Views/Home/ComplexModel.cshtml
+++ b/FoolProof.Core.Tests.WebApp/Views/Home/ComplexModel.cshtml
@@ -4,7 +4,7 @@
     ViewData["ValidatorName"] = "Complex Model Validation";
 }
 
-<form asp-action="Save" method="post" class="d-flex flex-column gap-4">
+<form method="post" class="d-flex flex-column gap-4">
     @if (!string.IsNullOrWhiteSpace(ViewBag.SuccessMessage))
     {
         <div class="alert alert-success alert-dismissible m-4">

--- a/FoolProof.Core/Base Classes/ContingentValidationAttribute.cs
+++ b/FoolProof.Core/Base Classes/ContingentValidationAttribute.cs
@@ -11,24 +11,20 @@ namespace FoolProof.Core
         public string DependentProperty { get; private set; }
         public string DependentPropertyDisplayName { get; set; }
 
-        public ContingentValidationAttribute(string dependentProperty)
+        public ContingentValidationAttribute(string dependentProperty) : this(dependentProperty, "{0} is invalid due to {1}.")
+        {
+        }
+
+        public ContingentValidationAttribute(string dependentProperty, string defaultMessage) : base(defaultMessage)
         {
             DependentProperty = dependentProperty;
         }
         
         public override string FormatErrorMessage(string name)
         {
-            if (string.IsNullOrEmpty(ErrorMessageResourceName) && string.IsNullOrEmpty(ErrorMessage))
-                ErrorMessage = DefaultErrorMessage;
-            
             return string.Format(ErrorMessageString, name, DependentPropertyDisplayName ?? DependentProperty);
         }
 
-        public override string DefaultErrorMessage
-        {
-            get { return "{0} is invalid due to {1}."; }
-        }
-        
         public override bool IsValid(object value, object container)
         {
             return IsValid(value, GetDependentPropertyValue(container), container);

--- a/FoolProof.Core/Base Classes/ModelAwareValidationAttribute.cs
+++ b/FoolProof.Core/Base Classes/ModelAwareValidationAttribute.cs
@@ -9,20 +9,13 @@ namespace FoolProof.Core
     [AttributeUsage(AttributeTargets.Property)]
     public abstract class ModelAwareValidationAttribute : ValidationAttribute
     {
-        public override string FormatErrorMessage(string name)
+        protected ModelAwareValidationAttribute() : this("{0} is invalid.")
         {
-            if (string.IsNullOrEmpty(ErrorMessageResourceName) && string.IsNullOrEmpty(ErrorMessage))
-            {
-                ErrorMessage = DefaultErrorMessage;
-            }
-
-            return base.FormatErrorMessage(name);
         }
 
-        public virtual string DefaultErrorMessage
-        {
-            get { return "{0} is invalid."; }
-        }
+		protected ModelAwareValidationAttribute(string defaultMessage) : base(defaultMessage)
+		{
+		}
 
         public abstract bool IsValid(object value, object container);
 

--- a/FoolProof.Core/Is.cs
+++ b/FoolProof.Core/Is.cs
@@ -26,7 +26,7 @@ namespace FoolProof.Core
         private OperatorMetadata _metadata;
 
         public IsAttribute(Operator @operator, string dependentProperty)
-            : base(dependentProperty)
+            : base(dependentProperty, "{0} must be {2} {1}.")
         {
             Operator = @operator;
             PassOnNull = false;
@@ -57,10 +57,10 @@ namespace FoolProof.Core
             return _metadata.IsValid(value, dependentValue);
         }
 
-        public override string DefaultErrorMessage
-        {
-            get { return "{0} must be " + _metadata.ErrorMessage + " {1}."; }
-        }
+		public override string FormatErrorMessage(string name)
+		{
+			return string.Format(ErrorMessageString, name, DependentPropertyDisplayName ?? DependentProperty, _metadata.ErrorMessage);
+		}
 
         public static ClientDataType GetDataType(Type valueType)
         {

--- a/FoolProof.Core/RegularExpressionIf.cs
+++ b/FoolProof.Core/RegularExpressionIf.cs
@@ -9,7 +9,7 @@ namespace FoolProof.Core
         public string Pattern { get; set; }
 
         public RegularExpressionIfAttribute(string pattern, string dependentProperty, Operator @operator, object dependentValue)
-            : base(dependentProperty, @operator, dependentValue)
+            : base(dependentProperty, @operator, dependentValue, "{0} must be in the format of {3} due to {1} being {3} {2}")
         {
             Pattern = pattern;
             DataType = ClientDataType.String;
@@ -36,15 +36,7 @@ namespace FoolProof.Core
 
         public override string FormatErrorMessage(string name)
         {
-            if (string.IsNullOrEmpty(ErrorMessageResourceName) && string.IsNullOrEmpty(ErrorMessage))
-                ErrorMessage = DefaultErrorMessage;
-
-            return string.Format(ErrorMessageString, name, DependentPropertyDisplayName ?? DependentProperty, DependentValue, Pattern);
-        }
-
-        public override string DefaultErrorMessage
-        {
-            get { return "{0} must be in the format of {3} due to {1} being " + Metadata.ErrorMessage + " {2}"; }
+            return string.Format(ErrorMessageString, name, DependentPropertyDisplayName ?? DependentProperty, DependentValue, Pattern, Metadata.ErrorMessage);
         }
     }
 }

--- a/FoolProof.Core/RequiredIf.cs
+++ b/FoolProof.Core/RequiredIf.cs
@@ -14,13 +14,18 @@ namespace FoolProof.Core
         public ClientDataType? DataType { get; set; }
 
         protected OperatorMetadata Metadata { get; private set; }
-        
-        public RequiredIfAttribute(string dependentProperty, Operator @operator, object dependentValue)
-            : base(dependentProperty)
+
+		public RequiredIfAttribute(string dependentProperty, Operator @operator, object dependentValue, string defaultMessage)
+			: base(dependentProperty, defaultMessage)
+		{
+			Operator = @operator;
+			DependentValue = dependentValue;
+			Metadata = OperatorMetadata.Get(Operator);
+		}
+
+		public RequiredIfAttribute(string dependentProperty, Operator @operator, object dependentValue)
+            : this(dependentProperty, @operator, dependentValue, "{0} is required due to {1} being {3} {2}")
         {
-            Operator = @operator;
-            DependentValue = dependentValue;
-            Metadata = OperatorMetadata.Get(Operator);
         }
 
         public RequiredIfAttribute(string dependentProperty, object dependentValue)
@@ -28,10 +33,7 @@ namespace FoolProof.Core
 
         public override string FormatErrorMessage(string name)
         {
-            if (string.IsNullOrEmpty(ErrorMessageResourceName) && string.IsNullOrEmpty(ErrorMessage))
-                ErrorMessage = DefaultErrorMessage;
-
-            return string.Format(ErrorMessageString, name, DependentPropertyDisplayName ?? DependentProperty, DependentValue);
+            return string.Format(ErrorMessageString, name, DependentPropertyDisplayName ?? DependentProperty, DependentValue, Metadata.ErrorMessage);
         }
 
         public override string ClientTypeName
@@ -56,11 +58,6 @@ namespace FoolProof.Core
                 return value != null && !string.IsNullOrEmpty(value.ToString().Trim());
 
             return true;
-        }
-
-        public override string DefaultErrorMessage
-        {
-            get { return "{0} is required due to {1} being " + Metadata.ErrorMessage + " {2}"; }
         }
     }
 }

--- a/FoolProof.Core/RequiredIfEmpty.cs
+++ b/FoolProof.Core/RequiredIfEmpty.cs
@@ -4,7 +4,7 @@ namespace FoolProof.Core
     public class RequiredIfEmptyAttribute : ContingentValidationAttribute
     {
         public RequiredIfEmptyAttribute(string dependentProperty)
-            : base(dependentProperty) { }
+            : base(dependentProperty, "{0} is required due to {1} being empty.") { }
 
         public override bool IsValid(object value, object dependentValue, object container)
         {
@@ -12,11 +12,6 @@ namespace FoolProof.Core
                 return value != null && !string.IsNullOrEmpty(value.ToString().Trim());
 
             return true;
-        }
-
-        public override string DefaultErrorMessage
-        {
-            get { return "{0} is required due to {1} being empty."; }
         }
     }
 }

--- a/FoolProof.Core/RequiredIfNotEmpty.cs
+++ b/FoolProof.Core/RequiredIfNotEmpty.cs
@@ -4,7 +4,7 @@ namespace FoolProof.Core
     public class RequiredIfNotEmptyAttribute : ContingentValidationAttribute
     {
         public RequiredIfNotEmptyAttribute(string dependentProperty)
-            : base(dependentProperty) { }
+            : base(dependentProperty, "{0} is required due to {1} not being empty.") { }
 
         public override bool IsValid(object value, object dependentValue, object container)
         {
@@ -12,11 +12,6 @@ namespace FoolProof.Core
                 return value != null && !string.IsNullOrEmpty(value.ToString().Trim());
 
             return true;
-        }
-
-        public override string DefaultErrorMessage
-        {
-            get { return "{0} is required due to {1} not being empty."; }
         }
     }
 }


### PR DESCRIPTION
Modified default messages to use the appropriate `ValidationConstructor` constructor.